### PR TITLE
fix submit filter bug after job modification #163

### DIFF
--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -99,6 +99,10 @@ class Workflow < ActiveRecord::Base
     jobs.last.pbsid unless jobs.last.nil?
   end
 
+  def account
+    job_attrs[:account] unless job_attrs[:account].blank?
+  end
+
   # Define tasks to do after staging template directory typically copy over
   # uploaded files here
   # def after_stage(staged_dir)

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -95,10 +95,16 @@ class Workflow < ActiveRecord::Base
     File.directory?(staged_dir) ? Find.find(staged_dir).to_a[1..-1] : []
   end
 
+  # Returns the pbsid of the last job in the workflow
+  #
+  # @return [String, nil] the pbsid or nil if no jobs on the workflow
   def pbsid
     jobs.last.pbsid unless jobs.last.nil?
   end
 
+  # Returns the optional user-entered account string
+  #
+  # @return [String, nil] the account string or nil if blank
   def account
     job_attrs[:account] unless job_attrs[:account].blank?
   end


### PR DESCRIPTION
Proposed fix for https://github.com/OSC/ood-myjobs/issues/163

Returns `nil` on `account` calls if `job_attrs[:account]` is a blank string.