### PR TITLE
[WIP] Fix delete button line wrapping

### DIFF
--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -29,23 +29,23 @@
 
         <div class="panel-body">
           <a class="btn btn-default btn-sm btn-primary" id="open_dir_button" target="_blank" data-toggle="tooltip" title="Open Directory in File Manager" role="button" disabled>
-            <span class="glyphicon glyphicon-edit" aria-hidden="true"></span> Edit Files
+            <span class="glyphicon glyphicon-edit" aria-hidden="true"></span><span class="hidden-xs"> Edit Files</span>
           </a>
           <!-- <a class="btn btn-default btn-sm" id="view_button" data-toggle="tooltip" title="View Job" role="button" data-method="get" disabled><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span></a> -->
           <a class="btn btn-default btn-sm btn-primary" id="edit_button" data-toggle="tooltip" title="Specify Job Host and Script" role="button" data-method="get" disabled>
-            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Job Options
+            <span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="hidden-xs">  Job Options</span>
           </a>
           <a class="btn btn-default btn-sm btn-primary" id="terminal_button" target="_blank" data-toggle="tooltip" title="Open Selected Job in the Terminal" role="button" disabled>
-            <span class="glyphicon glyphicon-console" aria-hidden="true"></span> Open Terminal
+            <span class="glyphicon glyphicon-console" aria-hidden="true"></span><span class="hidden-xs"> Open Terminal</span>
           </a>
           <a class="btn btn-success btn-sm" id="submit_button" data-toggle="tooltip" title="Submit Job" role="button" data-method="get" disabled>
-            <span class="glyphicon glyphicon-play" aria-hidden="true"></span> Submit
+            <span class="glyphicon glyphicon-play" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  submit</span>
           </a>
           <a class="btn btn-default btn-sm btn-warning" id="stop_button" data-toggle="tooltip" title="Stop Job" role="button" data-method="get" disabled>
-            <span class="glyphicon glyphicon-stop" aria-hidden="true"></span> Stop
+            <span class="glyphicon glyphicon-stop" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  Stop</span>
           </a>
           <a class="btn btn-danger btn-sm pull-right" id="destroy_button" data-toggle="tooltip" title="Delete Job" data-method="get" data-confirm="Are you sure?" role="button" disabled>
-            <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete
+            <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> <span class="hidden-xs hidden-sm hidden-md"> Delete</span>
           </a>
         </div>
 


### PR DESCRIPTION
Fixes #104 

When making window smaller, delete, submit, and stop buttons wrap onto
second line, looking ugly and not usable. This hides the text for all the buttons when making the window smaller, similar to how the dashboard navbar works.

A better solution might be to use flexbox on these buttons, instead of left margin on the submit button and delete button, to space them out. That way when the window expands, the submit and stop are in the middle, with the margins to left and right expand or contract with the available space.

Next steps:

1. Switch to using Flexbox for these buttons
2. If there is still line wrapping after all of these buttons come together, switch to just showing icons (possibly only using class hidden-xs)