### PR TITLE
refresh job panel when a user returns to a page. addresses #167

### DIFF
--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -2,6 +2,10 @@
 # All this logic will automatically be available in application.js.
 # You can use CoffeeScript in this file: http://coffeescript.org/
 
+$(window).focus ->
+  update_display(active_var())
+  return
+
 @update_display = (id) ->
   request_job_data(id)
   update_destroy_button(id)

--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -55,15 +55,15 @@ $(window).focus ->
 
 @show_job_panel = (show) ->
   if show?
-    $("#job-details-panel").fadeIn(200)
+    $("#job-details-panel").fadeIn(50)
   else
-    $("#job-details-panel").fadeOut(100)
+    $("#job-details-panel").fadeOut(50)
 
 @show_script_details_panel = (show) ->
   if show?
-    $("#script-details-panel").fadeIn(200)
+    $("#script-details-panel").fadeIn(50)
   else
-    $("#script-details-panel").fadeOut(100)
+    $("#script-details-panel").fadeOut(50)
 
 @update_status_label = (id, label) ->
   if label? && id?


### PR DESCRIPTION
when the user leaves the browser window (i.e. to enter an editing tab) and then returns to myjobs, the app refreshes the script data panel.

This ensures the script text is refreshed after edit.

Tested ok in latest editions of IE11/Edge/Chrome/Firefox/Safari