### PR TITLE
Hide button text to prevent wrapping

### DIFF
--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -27,23 +27,23 @@
     <div id="job-list-view" class="panel panel-default">
       <div class="panel-body">
         <a class="btn btn-default btn-sm btn-primary" id="open_dir_button" target="_blank" data-toggle="tooltip" title="Open Directory in File Manager" role="button" disabled>
-          <span class="glyphicon glyphicon-edit" aria-hidden="true"></span> Edit Files
+          <span class="glyphicon glyphicon-edit" aria-hidden="true"></span><span class="hidden-xs"> Edit Files</span>
         </a>
         <!-- <a class="btn btn-default btn-sm" id="view_button" data-toggle="tooltip" title="View Job" role="button" data-method="get" disabled><span class="glyphicon glyphicon-eye-open" aria-hidden="true"></span></a> -->
         <a class="btn btn-default btn-sm btn-primary" id="edit_button" data-toggle="tooltip" title="Specify Job Host and Script" role="button" data-method="get" disabled>
-          <span class="glyphicon glyphicon-cog" aria-hidden="true"></span> Job Options
+          <span class="glyphicon glyphicon-cog" aria-hidden="true"></span><span class="hidden-xs">  Job Options</span>
         </a>
         <a class="btn btn-default btn-sm btn-primary" id="terminal_button" target="_blank" data-toggle="tooltip" title="Open Selected Job in the Terminal" role="button" disabled>
-          <span class="glyphicon glyphicon-console" aria-hidden="true"></span> Open Terminal
+          <span class="glyphicon glyphicon-console" aria-hidden="true"></span><span class="hidden-xs"> Open Terminal</span>
         </a>
         <a class="btn btn-success btn-sm" id="submit_button" data-toggle="tooltip" title="Submit Job" role="button" data-method="get" disabled>
-          <span class="glyphicon glyphicon-play" aria-hidden="true"></span> Submit
+          <span class="glyphicon glyphicon-play" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  submit</span>
         </a>
         <a class="btn btn-default btn-sm btn-warning" id="stop_button" data-toggle="tooltip" title="Stop Job" role="button" data-method="get" disabled>
-          <span class="glyphicon glyphicon-stop" aria-hidden="true"></span> Stop
+          <span class="glyphicon glyphicon-stop" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  Stop</span>
         </a>
         <a class="btn btn-danger btn-sm pull-right" id="destroy_button" data-toggle="tooltip" title="Delete Job" data-method="get" data-confirm="Are you sure?" role="button" disabled>
-          <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete
+          <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> <span class="hidden-xs hidden-sm hidden-md"> Delete</span>
         </a>
       </div>
 

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -37,13 +37,13 @@
           <span class="glyphicon glyphicon-console" aria-hidden="true"></span><span class="hidden-xs"> Open Terminal</span>
         </a>
         <a class="btn btn-success btn-sm" id="submit_button" data-toggle="tooltip" title="Submit Job" role="button" data-method="get" disabled>
-          <span class="glyphicon glyphicon-play" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  submit</span>
+          <span class="glyphicon glyphicon-play" aria-hidden="true"></span><span class="hidden-xs hidden-md">  submit</span>
         </a>
         <a class="btn btn-default btn-sm btn-warning" id="stop_button" data-toggle="tooltip" title="Stop Job" role="button" data-method="get" disabled>
-          <span class="glyphicon glyphicon-stop" aria-hidden="true"></span><span class="hidden-xs hidden-sm hidden-md">  Stop</span>
+          <span class="glyphicon glyphicon-stop" aria-hidden="true"></span><span class="hidden-xs hidden-md">  Stop</span>
         </a>
         <a class="btn btn-danger btn-sm pull-right" id="destroy_button" data-toggle="tooltip" title="Delete Job" data-method="get" data-confirm="Are you sure?" role="button" disabled>
-          <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> <span class="hidden-xs hidden-sm hidden-md"> Delete</span>
+          <span class="glyphicon glyphicon-trash" aria-hidden="true"></span> <span class="hidden-xs hidden-md"> Delete</span>
         </a>
       </div>
 

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -16,7 +16,9 @@
 
         <a class="btn btn-default btn-sm btn-info" id="copy_button" data-toggle="tooltip" title="Copy Job" role="button" data-method="get" disabled><span class="glyphicon glyphicon-duplicate" aria-hidden="true"></span> Copy Job</a>
 
-        <a class="pull-right btn btn-default btn-sm btn-templates" id="template_button" data-toggle="tooltip" title="Create template from selected job" data-method="get" role="button" disabled><span class="glyphicon glyphicon-star-empty" aria-hidden="true"></span> Create Template</a>
+        <a class="pull-right btn btn-default btn-sm btn-templates" id="template_button" data-toggle="tooltip" title="Create template from selected job" data-method="get" role="button" disabled>
+          <span class="glyphicon glyphicon-star-empty" aria-hidden="true"></span><span class="hidden-xs hidden-md"> Create Template</span>
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Fixes #104 

When browser window becomes small, hide button text on submit, stop, delete
to prevent button wrapping