### PR TITLE
Remove the caret from the disabled workflow selectpicker

### DIFF
--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -75,7 +75,7 @@ $(window).focus ->
   show_job_panel()
   if data?
     $("#job-details-name").text(data.name)
-    $("#job-details-server-select option[value=#{data.batch_host}]").prop("selected", "selected")
+    $("#job-details-server").val(data.host_title)
     $("#job-details-staged-dir").text(data.staged_dir)
     if data.account == null or data.account == ""
       $("#job-details-account").addClass("text-muted")

--- a/app/assets/stylesheets/workflows.css.scss
+++ b/app/assets/stylesheets/workflows.css.scss
@@ -28,16 +28,3 @@ tr.missing {
     font-style: italic;
   }
 }
-
-// Hide the caret on the disabled selectpicker
-.remove-caret  {
-  appearance: none;
-  -webkit-appearance: none;
-  -moz-appearance: none;
-  text-indent: 1px;
-}
-
-// Hide the caret on the disabled selectpicker (IE)
-.remove-caret::-ms-expand {
-  display: none;
-}

--- a/app/assets/stylesheets/workflows.css.scss
+++ b/app/assets/stylesheets/workflows.css.scss
@@ -28,3 +28,16 @@ tr.missing {
     font-style: italic;
   }
 }
+
+// Hide the caret on the disabled selectpicker
+.remove-caret  {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  text-indent: 1px;
+}
+
+// Hide the caret on the disabled selectpicker (IE)
+.remove-caret::-ms-expand {
+  display: none;
+}

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -91,7 +91,7 @@
       <div class="panel-body">
         <p>Job Name: <h4><strong><span id="job-details-name"></span></strong></h4></p>
         <p>Submit to:</p>
-          <select class="form-control" id="job-details-server-select" disabled>
+          <select class="form-control remove-caret" id="job-details-server-select" disabled>
             <% OODClusters.each do |cluster| %>
                 <option id="<%= cluster.id %>" value="<%= cluster.id %>"><%= cluster.metadata_config[:title] %></option>
             <% end %>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -91,11 +91,7 @@
       <div class="panel-body">
         <p>Job Name: <h4><strong><span id="job-details-name"></span></strong></h4></p>
         <p>Submit to:</p>
-          <select class="form-control remove-caret" id="job-details-server-select" disabled>
-            <% OODClusters.each do |cluster| %>
-                <option id="<%= cluster.id %>" value="<%= cluster.id %>"><%= cluster.metadata_config[:title] %></option>
-            <% end %>
-          </select>
+          <input type="text" class="form-control" id="job-details-server" disabled>
         <p></p>
         <p>Account:</p>
         <p id="job-details-account"></p>

--- a/app/views/workflows/show.json.jbuilder
+++ b/app/views/workflows/show.json.jbuilder
@@ -1,7 +1,9 @@
 json.extract! @workflow, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account
 json.set! 'status_label', status_label(@workflow)
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)
-json.set! 'host_title', @workflow.batch_host.titleize
+json.set! 'host_title', OODClusters[@workflow.batch_host] ?
+    OODClusters[@workflow.batch_host].metadata.title || @workflow.batch_host.titleize :
+    "Select a valid cluster in \"Job Options\""
 json.folder_contents (@workflow.folder_contents) do |content|
   json.set! 'path', content
   json.set! 'name', Pathname(content).basename.to_s

--- a/app/views/workflows/show.json.jbuilder
+++ b/app/views/workflows/show.json.jbuilder
@@ -1,6 +1,7 @@
 json.extract! @workflow, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account
 json.set! 'status_label', status_label(@workflow)
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)
+json.set! 'host_title', @workflow.batch_host.titleize
 json.folder_contents (@workflow.folder_contents) do |content|
   json.set! 'path', content
   json.set! 'name', Pathname(content).basename.to_s

--- a/app/views/workflows/show.json.jbuilder
+++ b/app/views/workflows/show.json.jbuilder
@@ -3,7 +3,7 @@ json.set! 'status_label', status_label(@workflow)
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)
 json.set! 'host_title', OODClusters[@workflow.batch_host] ?
     OODClusters[@workflow.batch_host].metadata.title || @workflow.batch_host.titleize :
-    "Select a valid cluster in \"Job Options\""
+    @workflow.batch_host.titleize
 json.folder_contents (@workflow.folder_contents) do |content|
   json.set! 'path', content
   json.set! 'name', Pathname(content).basename.to_s


### PR DESCRIPTION
* Removes the arrow from the disabled selectpicker to avoid confusion.

![capture](https://cloud.githubusercontent.com/assets/2374718/25152671/caac5a38-2457-11e7-89c1-94201e0b0762.PNG)
