### PR TITLE
Resubmit a submitted or failed job

### DIFF
--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -161,7 +161,7 @@ $(window).focus ->
     $("#terminal_button").bind('click', false)
 
 @update_submit_button = (id, status_char) ->
-  if id? && !status_char?
+  if id? && status_char != "R" && status_char != "Q"
       $("#submit_button").attr("href", Routes.submit_workflow_path(id))
       $("#submit_button").data("method", "PUT")
       $("#submit_button").removeAttr("disabled")

--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -28,8 +28,8 @@ $(window).focus ->
         update_open_dir_button(data.fs_root)
         update_edit_button(id)
         update_copy_button(id)
-        update_submit_button(id, data.status.char)
-        update_stop_button(id, data.status.char)
+        update_submit_button(id, data.active)
+        update_stop_button(id, data.active)
         update_template_button(id)
         list_folder_contents(data)
         if missing_data_path()
@@ -160,8 +160,8 @@ $(window).focus ->
     $("#terminal_button").attr("disabled", true)
     $("#terminal_button").bind('click', false)
 
-@update_submit_button = (id, status_char) ->
-  if id? && status_char != "R" && status_char != "Q"
+@update_submit_button = (id, active) ->
+  if id? && !active
       $("#submit_button").attr("href", Routes.submit_workflow_path(id))
       $("#submit_button").data("method", "PUT")
       $("#submit_button").removeAttr("disabled")
@@ -171,8 +171,8 @@ $(window).focus ->
     $("#submit_button").attr("disabled", true)
     $("#submit_button").bind('click', false)
 
-@update_stop_button = (id, status_char) ->
-  if id? && status_char? && (status_char == "R" || status_char == "Q")
+@update_stop_button = (id, active) ->
+  if id? && active
     $("#stop_button").attr("href", Routes.stop_workflow_path(id))
     $("#stop_button").data("method", "PUT")
     $("#stop_button").removeAttr("disabled")

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -128,10 +128,10 @@ class WorkflowsController < ApplicationController
   def submit
     set_workflow
 
-    # We want to allow the user to resubmit a job that has been run or failed. This will clear old jobs from
-    # a workflow when the job is no longer queued or running, which will clear the submitted state.
+    # We want to allow the user to resubmit a job that has been run or failed. This will destroy all preexisting
+    # job records for this workflow when the job is no longer queued or running, which will clear the submitted state.
     if @workflow.submitted? && !@workflow.active?
-      @workflow.jobs.clear
+      @workflow.jobs.destroy_all
     end
 
     respond_to do |format|

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -127,6 +127,9 @@ class WorkflowsController < ApplicationController
   # PUT /workflows/1/submit.json
   def submit
     set_workflow
+
+    # We want to allow the user to resubmit a job that has been run or failed. This will clear old jobs from
+    # a workflow when the job is no longer queued or running, which will clear the submitted state.
     if @workflow.submitted? && !@workflow.active?
       @workflow.jobs.clear
     end

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -127,6 +127,9 @@ class WorkflowsController < ApplicationController
   # PUT /workflows/1/submit.json
   def submit
     set_workflow
+    if @workflow.submitted? && !@workflow.active?
+      @workflow.jobs.clear
+    end
 
     respond_to do |format|
       if @workflow.submitted?

--- a/app/views/workflows/show.json.jbuilder
+++ b/app/views/workflows/show.json.jbuilder
@@ -1,5 +1,6 @@
 json.extract! @workflow, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account
 json.set! 'status_label', status_label(@workflow)
+json.set! 'active', @workflow.active?
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)
 json.set! 'host_title', OODClusters[@workflow.batch_host] ?
     OODClusters[@workflow.batch_host].metadata.title || @workflow.batch_host.titleize :


### PR DESCRIPTION
Resolves #206 

* Re-enables the submit button on inactive jobs
* Clears the existing jobs out of a workflow when an inactive job is submitted, allowing it to be submitted again.