### PR TITLE
Show the script name in the job options

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -66,8 +66,6 @@ $(document).ready(function(){
                 table.$('tr.active').removeClass('active');
                 $(this).addClass('active');
             }
-            update_missing_data_path_view();
-            update_missing_data_script_view(active_var());
             update_display(active_var());
         });
     }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -67,6 +67,7 @@ $(document).ready(function(){
                 $(this).addClass('active');
             }
             update_missing_data_path_view();
+            update_missing_data_script_view(active_var());
             update_display(active_var());
         });
     }

--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -74,6 +74,8 @@ $(window).focus ->
 @update_job_details_panel = (data) ->
   show_job_panel()
   if data?
+    update_missing_data_path_view()
+    update_missing_data_script_view()
     $("#job-details-name").text(data.name)
     $("#job-details-server").val(data.host_title)
     $("#job-details-staged-dir").text(data.staged_dir)
@@ -344,10 +346,13 @@ $ ->
   active_row().hasClass('missing-script')
 
 @update_missing_data_path_view = ->
-  $('#script-details-view').toggleClass("missing-dir", missing_data_path());
+  $('#script-details-view').toggleClass("missing-dir", missing_data_path())
 
-@update_missing_data_script_view = (id) ->
-  $('#script-details-name-view').toggleClass("missing-script", missing_data_script());
+@update_missing_data_script_view = ->
+  # No need to show this block if the directory is invalid
+  $('#script-details-name-view').toggle(!missing_data_path())
+  $('#script-details-name-view').toggleClass("missing-script", missing_data_script())
+  $("#edit-job-options-link").attr("href", Routes.edit_workflow_path(active_var()))
 
 $ ->
   $('#reset-template-data').on 'click', ->

--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -77,6 +77,7 @@ $(window).focus ->
     $("#job-details-name").text(data.name)
     $("#job-details-server").val(data.host_title)
     $("#job-details-staged-dir").text(data.staged_dir)
+    $("#job-details-script-name").text(data.staged_script_name || ' ')
     if data.account == null or data.account == ""
       $("#job-details-account").addClass("text-muted")
       $("#job-details-account").text("Not specified")
@@ -337,10 +338,16 @@ $ ->
   $("#template-folder-contents").html("#{list}")
 
 @missing_data_path = ->
-  active_row().hasClass('missing')
+  active_row().hasClass('missing-dir')
+
+@missing_data_script = ->
+  active_row().hasClass('missing-script')
 
 @update_missing_data_path_view = ->
-  $('#script-details-view').toggleClass("missing", missing_data_path());
+  $('#script-details-view').toggleClass("missing-dir", missing_data_path());
+
+@update_missing_data_script_view = (id) ->
+  $('#script-details-name-view').toggleClass("missing-script", missing_data_script());
 
 $ ->
   $('#reset-template-data').on 'click', ->

--- a/app/assets/stylesheets/workflows.css.scss
+++ b/app/assets/stylesheets/workflows.css.scss
@@ -15,7 +15,8 @@ tr.missing-dir {
   min-height: 100vh;
 }
 
-#script-details-view .help-block-dir, .help-block-script {
+#script-details-view .help-block-dir,
+#script-details-name-view .help-block-script {
   display: none;
 }
 

--- a/app/assets/stylesheets/workflows.css.scss
+++ b/app/assets/stylesheets/workflows.css.scss
@@ -7,7 +7,7 @@
   overflow-y: auto;
 }
 
-tr.missing {
+tr.missing-dir {
   @extend .bg-danger;
 }
 
@@ -15,14 +15,24 @@ tr.missing {
   min-height: 100vh;
 }
 
-#script-details-view .help-block {
+#script-details-view .help-block-dir, .help-block-script {
   display: none;
 }
 
-#script-details-view.missing {
+#script-details-view.missing-dir {
   color: #a94442;
 
-  .help-block {
+  .help-block-dir {
+    color: #a94442;
+    display: block;
+    font-style: italic;
+  }
+}
+
+#script-details-name-view.missing-script {
+  color: #a94442;
+
+  .help-block-script {
     color: #a94442;
     display: block;
     font-style: italic;

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -55,8 +55,12 @@ class Workflow < ActiveRecord::Base
     self.script_name
   end
 
+  def staged_script_exists?
+    File.file? self.script_path
+  end
+
   def script_path
-    Pathname.new(self.staged_dir).join(self.script_name)
+    Pathname.new(self.staged_dir).join(self.script_name.to_s)
   end
 
   def script_path=(new_path)

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -108,7 +108,7 @@
         <div id="script-details-name-view">
           <p>Script name:</p>
           <pre id="job-details-script-name" disabled></pre>
-          <p class="help-block-script"><i>Script is not valid!</i></p>
+          <p class="help-block-script"><i>Script is not valid! Edit <a href="#" id="edit-job-options-link">Job Options</a> to select a valid script.</i></p>
         </div>
       </div>
 

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -68,7 +68,7 @@
 
           <tbody>
           <% @workflows.each do |workflow| %>
-              <tr class="job-row <%= "missing" unless workflow.staged_dir_exists? %>" id="<%=workflow.id %>">
+              <tr class="job-row<%= " missing-dir" unless workflow.staged_dir_exists? %><%= " missing-script" unless workflow.script_name && workflow.staged_script_exists? %>" id="<%= workflow.id %>">
                 <td data-sort="<%= workflow.id %>"><small><%= local_time(workflow.created_at) %></small></td>
                 <td><strong><%= workflow.name %></strong></td>
                 <td><%= workflow.pbsid %></td>
@@ -99,10 +99,17 @@
         <p id="job-details-account"></p>
       </div>
 
-      <div id="script-details-view" class="panel-body">
-        <p>Script location:</p>
-        <pre id="job-details-staged-dir"></pre>
-        <p class="help-block"><i>Job Directory is missing!</i></p>
+      <div class="panel-body">
+        <div id="script-details-view">
+          <p>Script location:</p>
+          <pre id="job-details-staged-dir"></pre>
+          <p class="help-block-dir"><i>Job Directory is missing!</i></p>
+        </div>
+        <div id="script-details-name-view">
+          <p>Script name:</p>
+          <pre id="job-details-script-name" disabled></pre>
+          <p class="help-block-script"><i>Script is not valid!</i></p>
+        </div>
       </div>
 
       <div id="job-details-view" class="panel-body folder-content-view">


### PR DESCRIPTION
Resolves #214 

* Adds a box showing the name of the script
* Shows a warning if the script is not a valid file and provides instructions for editing options
* Hides the script name if the workflow directory is invalid