### PR TITLE
Don't show an app path when creating new template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix bug where new template path isn't blank
+
 # v2.4.1
 
 * Fix bug in `bin/setup` that crashes when `OOD_PORTAL` is set but not

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -30,7 +30,7 @@ class Template
     # We want to convert the full path if a user enters an alias like `~\path`.
     # Calling .expand_path on an invalid location will fail. We rescue here and resort to the user-defined path.
     # Validations that inform the user of the non-existence of the path are handled in the controller.
-    @path = path.blank? ? Pathname.new(path) : Pathname.new(path).expand_path rescue Pathname.new(path)
+    @path = expand_pathname_if_valid(path)
     @source = source
   end
 
@@ -92,5 +92,16 @@ class Template
     # Sort templates by name
     self.name.upcase <=> o.name.upcase
   end
+
+  private
+
+    # Returns an expanded path
+    def expand_pathname_if_valid(path)
+      if path.blank?
+        Pathname.new(path)
+      else
+        Pathname.new(path).expand_path rescue Pathname.new(path)
+      end
+    end
 
 end

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -27,7 +27,10 @@ class Template
   # @param [String] path The template base path.
   # @param [optional, Source] source A Source object based on the template's location.
   def initialize(path, source = Source.new("", Pathname.new("")))
-    @path = Pathname.new(path).expand_path rescue Pathname.new(path)
+    # We want to convert the full path if a user enters an alias like `~\path`.
+    # Calling .expand_path on an invalid location will fail. We rescue here and resort to the user-defined path.
+    # Validations that inform the user of the non-existence of the path are handled in the controller.
+    @path = path.blank? ? Pathname.new(path) : Pathname.new(path).expand_path rescue Pathname.new(path)
     @source = source
   end
 
@@ -89,4 +92,5 @@ class Template
     # Sort templates by name
     self.name.upcase <=> o.name.upcase
   end
+
 end


### PR DESCRIPTION
Fixes #220 

Calling `expand_path` on a blank `Pathname` sets the path to the app root. I added a check to work around this.