### PR TITLE
Remove therubyracer gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Removed
+
+- Removed `therubyracer` gem requirement in favor of `nodejs010`.
+
 ## [2.6.0] - 2017-09-27
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'coffee-rails', '~> 4.0.0'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
-gem 'therubyracer', platforms: :ruby
+# gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,7 +73,6 @@ GEM
       railties (>= 3.2)
       sprockets-rails
     json (1.8.6)
-    libv8 (3.16.14.19)
     local_time (1.0.3)
       coffee-rails
     lograge (0.6.0)
@@ -138,7 +137,6 @@ GEM
     rake (12.0.0)
     rdoc (4.3.0)
     redcarpet (3.4.0)
-    ref (2.0.0)
     request_store (1.3.2)
     sass (3.4.23)
     sass-rails (5.0.6)
@@ -158,9 +156,6 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.13)
-    therubyracer (0.12.3)
-      libv8 (~> 3.16.14.15)
-      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.7)
@@ -193,5 +188,4 @@ DEPENDENCIES
   sass-rails (~> 5.0.0)
   sdoc
   sqlite3 (~> 1.3.11)
-  therubyracer
   uglifier (>= 1.3.0)


### PR DESCRIPTION
Removed so that nodejs will be used as default js engine.

I just commented it out here because `therubyracer` is one of the boilerplate rails dependencies. This way future generations will know that it's commented out by design and not omission.

The documentation already includes `nodejs010` in the build step so I didn't add it here.