### PR TITLE
[DO NOT MERGE] Example with global configuration

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-APP_VERSION=$(git describe --always --tags)
-
-OOD_DATAROOT=$PWD/data
-
-# for testing app integrations, you can use a local copy of the app instead
-# OOD_DASHBOARD_URL="/pun/dev/dashboard"
-# OOD_FILES_URL="/pun/usr/bmcmichael/cloudcmd"
-# OOD_SHELL_URL="/pun/usr/jnicklas/osc-shell"

--- a/.env.local.osc.awesim.production
+++ b/.env.local.osc.awesim.production
@@ -1,2 +1,0 @@
-OOD_DATAROOT=$HOME/$OOD_PORTAL/data/sys/myjobs
-DATABASE_PATH=$OOD_DATAROOT/production.sqlite3

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,1 @@
 RAILS_RELATIVE_URL_ROOT=/pun/sys/myjobs
-
-OOD_DATAROOT=$HOME/ondemand/data/sys/myjobs
-DATABASE_PATH=$OOD_DATAROOT/production.sqlite3

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -80,7 +80,7 @@
       <hr>
       <div class="row">
         <div class="col-sm-12">
-          <p id="app_version" class="pull-right"><%= ENV['APP_VERSION'] %></p>
+          <p id="app_version" class="pull-right"><%= Configuration.version %></p>
         </div>
       </div>
   </footer>

--- a/bin/setup-production
+++ b/bin/setup-production
@@ -23,17 +23,20 @@ chdir APP_ROOT do
   # get env vars for DATABASE and DATAROOT
   Dotenv.load(".env.local", ".env.production", ".env")
 
-  `mkdir -p #{ENV["OOD_DATAROOT"]}` if ENV["OOD_DATAROOT"]
+  # Load the dashboard specific configuration.
+  require APP_ROOT.join("config", "configuration").to_s
+
+  `mkdir -p #{Configuration.dataroot}`
 
   # currently SQLite-specific
-  if File.exist?(ENV["DATABASE_PATH"])
+  if File.exist?(Configuration.prod_database)
     # Get a list of all migration for this app
     app_migrations = Dir.glob("#{APP_ROOT}/db/migrate/*").map {|v| File.basename(v).split("_").first}
 
     # Read in current migrations from database
     require 'sqlite3'
     begin
-      db = SQLite3::Database.new ENV["DATABASE_PATH"]
+      db = SQLite3::Database.new Configuration.prod_database
       db_migrations = db.execute("SELECT * FROM schema_migrations").map {|v| v.first}
     rescue SQLite3::Exception => e
       abort "Exception occurred: #{e}"

--- a/config/configuration.rb
+++ b/config/configuration.rb
@@ -40,22 +40,26 @@ class Configuration
     end
 
     # Id describing the OnDemand portal
-    # @return [String, nil] portal id
+    # @return [String] portal id
     def portal
-      config[:portal].try(:to_s) || ENV["OOD_PORTAL"]
+      config[:portal].try(:to_s) || ENV["OOD_PORTAL"] || "ondemand"
     end
 
     # Path to the data root for this app
-    # @return [String] data root
+    # @return [Pathname] data root
     def dataroot
-      config[:dataroot].try(:to_s) || ENV["OOD_DATAROOT"] ||
-        ( ENV["RAILS_ENV"] == "production" ? "#{ENV["HOME"]}/#{portal}/data/sys/myjobs" : "./data" )
+      Pathname.new(
+        config[:dataroot].try(:to_s) || ENV["OOD_DATAROOT"] ||
+          ( ENV["RAILS_ENV"] == "production" ? "~/#{portal}/data/sys/myjobs" : "./data" )
+      ).expand_path
     end
 
     # Path to the production database file for this app
-    # @return [String] database path
+    # @return [Pathname] database path
     def prod_database
-      config[:database].try(:to_s) || ENV["DATABASE_PATH"] || "#{dataroot}/production.sqlite3"
+      Pathname.new(
+        config[:database].try(:to_s) || ENV["DATABASE_PATH"] || dataroot.join("production.sqlite3")
+      )
     end
 
     # Title of Dashboard app
@@ -69,6 +73,6 @@ end
 # Set some environment variables to maintain backwards compatibility with
 # ood_appkit
 ENV["OOD_PORTAL"]          = Configuration.portal
-ENV["OOD_DATAROOT"]        = Configuration.dataroot
-ENV["DATABASE_PATH"]       = Configuration.prod_database
+ENV["OOD_DATAROOT"]        = Configuration.dataroot.to_s
+ENV["DATABASE_PATH"]       = Configuration.prod_database.to_s
 ENV["OOD_DASHBOARD_TITLE"] = Configuration.dashboard_title

--- a/config/configuration.rb
+++ b/config/configuration.rb
@@ -1,0 +1,74 @@
+require "yaml"
+require "erb"
+require "active_support/core_ext/hash/compact"
+require "active_support/core_ext/hash/keys"
+require "active_support/core_ext/object/try"
+
+# job composer app specific configuration
+class Configuration
+  class << self
+    # The app's configuration root directory
+    # @return [Pathname] path to configuration root
+    def config_root
+      Pathname.new(ENV["OOD_CONFIG"] || "/etc/ood/config/apps/myjobs")
+    end
+
+    # A hash describing the configuration read in from the app's configuration
+    # file
+    # @return [Hash{Symbol=>Object}] configuration hash
+    def config
+      return @config if @config
+
+      yaml = config_root.join("config.yml")
+      conf = YAML.load(ERB.new(yaml.read, nil, "-").result) if yaml.exist?
+      if conf.is_a?(Hash)
+        @config = conf.compact.deep_symbolize_keys
+      else
+        puts "ERROR: Configuration file '#{yaml}' needs to define a Hash" if conf
+        @config = {}
+      end
+    rescue Psych::SyntaxError => e
+      puts "ERROR: YAML syntax error occurred while parsing #{yaml} - #{e.message}"
+      @config = {}
+    end
+
+    # Version of app
+    # @return [String] app version
+    def version
+      version = `git describe --always --tags 2> /dev/null`.strip
+      version.empty? ? "Unknown Version" : version
+    end
+
+    # Id describing the OnDemand portal
+    # @return [String, nil] portal id
+    def portal
+      config[:portal].try(:to_s) || ENV["OOD_PORTAL"]
+    end
+
+    # Path to the data root for this app
+    # @return [String] data root
+    def dataroot
+      config[:dataroot].try(:to_s) || ENV["OOD_DATAROOT"] ||
+        ( ENV["RAILS_ENV"] == "production" ? "#{ENV["HOME"]}/#{portal}/data/sys/myjobs" : "./data" )
+    end
+
+    # Path to the production database file for this app
+    # @return [String] database path
+    def prod_database
+      config[:database].try(:to_s) || ENV["DATABASE_PATH"] || "#{dataroot}/production.sqlite3"
+    end
+
+    # Title of Dashboard app
+    # @return [String, nil] title of dashboard
+    def dashboard_title
+      config[:dashboard_title].try(:to_s) || ENV["OOD_DASHBOARD_TITLE"]
+    end
+  end
+end
+
+# Set some environment variables to maintain backwards compatibility with
+# ood_appkit
+ENV["OOD_PORTAL"]          = Configuration.portal
+ENV["OOD_DATAROOT"]        = Configuration.dataroot
+ENV["DATABASE_PATH"]       = Configuration.prod_database
+ENV["OOD_DASHBOARD_TITLE"] = Configuration.dashboard_title

--- a/config/database.yml
+++ b/config/database.yml
@@ -22,4 +22,4 @@ test:
 
 production:
   <<: *default
-  database: <%= ENV['DATABASE_PATH'] %>
+  database: <%= Configuration.prod_database %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,5 +1,13 @@
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 
+# Load the dashboard specific configuration.
+require File.expand_path('../configuration', __FILE__)
+
+# Include custom initializers
+Rails.application.configure do |config|
+  config.paths["config/initializers"] << Configuration.config_root.join("initializers").to_s
+end
+
 # Initialize the Rails application.
 Rails.application.initialize!


### PR DESCRIPTION
@ericfranz here is an example for Job Composer with a global configuration that works with `bin/setup-production`.

It is also *theoretically* backwards compatible with any `.env.local` that may exist already.

Couple of changes from the Dashboard were made:

- I cache the config file now as some of the options can't be dynamically changed.
- I broke out the code for adding the initializer path so that `Configuration` is a class that doesn't depend on `Rails`.
- I load the `config/configuration.rb` in the `bin/setup-production` so that configuration options are used instead of env vars.
- Configuration options now have priority over environment variables, so a sys admin can begin modifying a configuration file right away and not have to worry about deleting the corresponding env var in the `.env.local`.