### PR TITLE
Fix bug copy job from selected #245

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
+### Fixed
+- Fix bug when copying job from existing. [#245](https://github.com/OSC/ood-myjobs/issues/245)
 
 ## [2.6.1] - 2017-10-20
 ### Changed

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -21,7 +21,7 @@
               <% end %>
               <li><a href="<%= new_from_path_path %>">From Specified Path</a></li>
               <li role="separator" class="divider"></li>
-              <li><a data-toggle="tooltip" title="Copy the selected job" data-method="get" disabled>From Selected Job</a></li>
+              <li><a id="copy_button" data-toggle="tooltip" title="Copy the selected job" data-method="put" disabled>From Selected Job</a></li>
             </ul>
           </div>
 


### PR DESCRIPTION
Fixes #245.

The element `id` was not set here so the javascript wasn't linked to it.