### PR TITLE
[DO NOT MERGE] Example modifications to add job options

### DIFF
--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -15,7 +15,7 @@ class Job < ActiveRecord::Base
       script: script,
       pbsid: pbsid,
       host: host || workflow.batch_host,
-      torque_helper: ResourceMgrAdapter.new
+      torque_helper: ResourceMgrAdapter.new(workflow)
     )
   end
 end

--- a/app/models/resource_mgr_adapter.rb
+++ b/app/models/resource_mgr_adapter.rb
@@ -4,6 +4,11 @@
 # OodJob errors will be caught and re-raised as PBS::Error objects
 class ResourceMgrAdapter
 
+  attr_reader :workflow
+
+  def initialize(workflow)
+    @workflow = workflow
+  end
 
   # TODO: this adapter could ignore the host argument and use the one that is
   # specified when it is instantiated.
@@ -23,7 +28,13 @@ class ResourceMgrAdapter
     raise OSC::Machete::Job::ScriptMissingError, "#{script_path} does not exist or cannot be read" unless script_path.file? && script_path.readable?
 
     cluster = cluster_for_host_id(host)
-    script = OodCore::Job::Script.new(content: script_path.read, accounting_id: account_string)
+    script = OodCore::Job::Script.new(
+      content: script_path.read,
+      accounting_id: account_string,
+      queue_name: workflow.queue_name,
+      email: workflow.email.presence,
+      email_on_started: workflow.email_on_started.present?
+    )
     adapter(cluster).submit( script, **depends_on)
 
   rescue OodCore::JobAdapterError => e

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ActiveRecord::Base
   # add accessors: [ :attr1, :attr2 ] etc. when you want to add getters and
   # setters to add new attributes stored in the JSON store
   # don't remove attributes from this list going forward! only deprecate
-  store :job_attrs, coder: JSON, accessors: [:account]
+  store :job_attrs, coder: JSON, accessors: [:account, :queue_name, :email, :email_on_started]
 
   attr_accessor :staging_template_dir
 
@@ -158,7 +158,7 @@ class Workflow < ActiveRecord::Base
       script: staged_dir.join(staged_script_name),
       host: batch_host,
       account_string: account,
-      torque_helper: ResourceMgrAdapter.new
+      torque_helper: ResourceMgrAdapter.new(self)
     )
   end
 

--- a/app/views/workflows/_edit_form_job_attrs.html.erb
+++ b/app/views/workflows/_edit_form_job_attrs.html.erb
@@ -5,3 +5,7 @@
 API at: https://github.com/bootstrap-ruby/rails-bootstrap-forms %>
 
 <%= f.text_field :account, help: "Account is optional field. If not set, the account may be auto-set by the submit filter." if Configuration.show_job_options_account_field? %>
+
+<%= f.text_field :email, help: "Your email address" %>
+<%= f.check_box :email_on_started, help: "Receive an email when this job starts" %>
+<%= f.select :queue_name, [["Serial", "batch"], ["Debug", "debug"], ["Parallel", "parallel"]] %>


### PR DESCRIPTION
Add queue dropdown, and email text field, and email on job start checkbox

We update ResourceManagerAdapter, our bridge class between the old osc-machete and
the new ood_core library, to accept the workflow it works with as an argument. Thus
ResourceManagerAdapter acts like a service object, and can set the arguments on the
ood_core script object.