### PR TITLE
Change icon to fas://magic

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -3,4 +3,5 @@ name: Job Composer
 category: Jobs
 description: |-
   Job Composer allows the creation and submission of batch jobs
-icon: fa://tasks
+icon: fas://magic
+


### PR DESCRIPTION
Originally:
![image](https://user-images.githubusercontent.com/38962417/44162197-9ecf0380-a08d-11e8-8546-c758a33f07f6.png)
Now:
![image](https://user-images.githubusercontent.com/38962417/44162246-cd4cde80-a08d-11e8-84f5-bb5220380c7a.png)

See: https://github.com/OSC/ood-dashboard/issues/341