### PR TITLE
Job array

### DIFF
--- a/app/assets/javascripts/workflows.js.coffee
+++ b/app/assets/javascripts/workflows.js.coffee
@@ -84,6 +84,15 @@ $(window).focus ->
   else
     $("#script-details-panel").hide()
 
+@show_job_array_request = (show) ->
+  if show
+    $("#job-details-job-array-request").show()
+    $("#job-details-job-array-request").prev().show()
+  else
+    $("#job-details-job-array-request").hide()
+    $("#job-details-job-array-request").prev().hide()
+
+
 @update_status_label = (id, label) ->
   if label? && id?
     $("#status_label_#{id}").html(label)
@@ -98,6 +107,8 @@ $(window).focus ->
     $("#job-details-server").val(data.host_title)
     $("#job-details-staged-dir").text(data.staged_dir)
     $("#job-details-script-name").text(data.staged_script_name || ' ')
+    $("#job-details-job-array-request").val(data.job_array_request || '')
+    show_job_array_request( !(data.job_array_request == null or data.job_array_request == '') )
     if data.account == null or data.account == ""
       $("#job-details-account").addClass("text-muted")
       $("#job-details-account").text("Not specified")

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -7,6 +7,7 @@ class WorkflowsController < ApplicationController
     if OODClusters.none?
       flash.now[:alert] = 'There are no configured hosts that allow you to submit jobs. Please contact your system administrator.'
     end
+
     @default_template = Template.default
     @templates = Template.all
 

--- a/app/models/job.rb
+++ b/app/models/job.rb
@@ -15,7 +15,7 @@ class Job < ActiveRecord::Base
       script: script,
       pbsid: pbsid,
       host: host || workflow.batch_host,
-      torque_helper: ResourceMgrAdapter.new
+      torque_helper: ResourceMgrAdapter.new(workflow)
     )
   end
 end

--- a/app/models/resource_mgr_adapter.rb
+++ b/app/models/resource_mgr_adapter.rb
@@ -4,6 +4,11 @@
 # OodJob errors will be caught and re-raised as PBS::Error objects
 class ResourceMgrAdapter
 
+  attr_reader :workflow
+
+  def initialize(workflow)
+    @workflow = workflow
+  end
 
   # TODO: this adapter could ignore the host argument and use the one that is
   # specified when it is instantiated.
@@ -23,7 +28,11 @@ class ResourceMgrAdapter
     raise OSC::Machete::Job::ScriptMissingError, "#{script_path} does not exist or cannot be read" unless script_path.file? && script_path.readable?
 
     cluster = cluster_for_host_id(host)
-    script = OodCore::Job::Script.new(content: script_path.read, accounting_id: account_string)
+    script = OodCore::Job::Script.new(
+      content: script_path.read,
+      accounting_id: account_string,
+      job_array_request: workflow.job_array_request.presence
+    )
     adapter(cluster).submit( script, **depends_on)
 
   rescue OodCore::JobAdapterError => e

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ActiveRecord::Base
   # add accessors: [ :attr1, :attr2 ] etc. when you want to add getters and
   # setters to add new attributes stored in the JSON store
   # don't remove attributes from this list going forward! only deprecate
-  store :job_attrs, coder: JSON, accessors: [:account]
+  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request]
 
   attr_accessor :staging_template_dir
 
@@ -158,7 +158,8 @@ class Workflow < ActiveRecord::Base
       script: staged_dir.join(staged_script_name),
       host: batch_host,
       account_string: account,
-      torque_helper: ResourceMgrAdapter.new
+      torque_helper: ResourceMgrAdapter.new(self),
+      job_array_request: job_array_request
     )
   end
 

--- a/app/views/workflows/_edit_form_job_attrs.html.erb
+++ b/app/views/workflows/_edit_form_job_attrs.html.erb
@@ -5,3 +5,5 @@
 API at: https://github.com/bootstrap-ruby/rails-bootstrap-forms %>
 
 <%= f.text_field :account, help: "Account is optional field. If not set, the account may be auto-set by the submit filter." if Configuration.show_job_options_account_field? %>
+
+<%= f.text_field :job_array_request, label: 'Job array specification', help: "Job arrays are optional." %>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -112,6 +112,8 @@
         <p></p>
         <p>Account:</p>
         <p id="job-details-account"></p>
+        <p>Job Array Request:</p>
+        <input type="text" class="form-control" id="job-details-job-array-request" disabled>
       </div>
 
       <div class="panel-body">

--- a/app/views/workflows/show.json.jbuilder
+++ b/app/views/workflows/show.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! @workflow, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account
+json.extract! @workflow, :name, :batch_host, :script_path, :staged_script_name, :staged_dir, :created_at, :updated_at, :status, :account, :job_array_request
 json.set! 'status_label', status_label(@workflow)
 json.set! 'active', @workflow.active?
 json.set! 'fs_root', Filesystem.new.fs(@workflow.staged_dir)


### PR DESCRIPTION
When used in conjunction with the `job_array` branch of `ood_core` this gives the user the ability to specify in the Job Options to specify a Job Array Request and can launch an array jobs. The currently set job array request is displayed to the user in the Job Details panel if there is a request or nothing is displayed if no job array has been requested.