### PR TITLE
Handle long job name

### DIFF
--- a/app/assets/javascripts/datatables.js.coffee
+++ b/app/assets/javascripts/datatables.js.coffee
@@ -10,7 +10,8 @@ jQuery ->
     columnDefs: [{
       orderable: false
       targets: 'no-sort'
-    }]
+    },
+    { "width": "50%", "targets": 1 }]
     iDisplayLength: 25
 
 jQuery ->
@@ -21,7 +22,8 @@ jQuery ->
     columnDefs: [{
       orderable: false
       targets: 'no-sort'
-    }]
+    },
+    { "width": "50%", "targets": 0 }]
     iDisplayLength: 10
 
 jQuery ->

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -22,7 +22,7 @@
 
 .table {
   width: 100%;
-  word-wrap: break-word;
+  table-layout: fixed;
 }
 
 .panel-thin {

--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -23,3 +23,9 @@
   margin-left: 70px;
 }
 
+
+.job-name{
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+}

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -82,7 +82,7 @@
           <% @workflows.each do |workflow| %>
               <tr class="job-row<%= " missing-cluster" unless workflow.batch_host_exists? %><%= " missing-dir" unless workflow.staged_dir_exists? %><%= " missing-script" unless workflow.script_name && workflow.staged_script_exists? %>" id="<%= workflow.id %>">
                 <td data-sort="<%= workflow.id %>"><small><%= local_time(workflow.created_at) %></small></td>
-                <td class="wrap-line"><strong><%= workflow.name %></strong></td>
+                <td class="job-name"><strong><%= workflow.name %></strong></td>
                 <td><%= workflow.pbsid %></td>
                 <td><%= cluster_title workflow.batch_host %></td>
                 <td id="status_label_<%= workflow.id %>"><%= status_label(workflow) %></td>

--- a/app/views/workflows/new.html.erb
+++ b/app/views/workflows/new.html.erb
@@ -50,7 +50,7 @@
           <tbody>
           <% @templates.each_with_index do |template, index| %>
             <tr class="job-row" data-name="<%= template.name %>" data-host="<%= template.host %>" data-path="<%= template.path %>" data-script="<%= template.manifest.script %>" data-api="<%= Filesystem.new.api(template.path) %>" data-fs="<%= Filesystem.new.fs(template.path) %>" data-shell="<%= OodAppkit.shell.url(path: template.path).to_s %>" data-notes="<%= template.notes %>" <%= "data-delete=#{template.path}" unless template.system? %> >
-              <td class="wrap-line"><%= template.name %></td>
+              <td class="job-name"><%= template.name %></td>
             <td><%= template.host.titleize %></td>
             <td><%= template.source.name %></td>
           </tr>


### PR DESCRIPTION
Set displayed length maximum to 80 for template table and job table
![truncated](https://user-images.githubusercontent.com/22674713/55249834-626aa500-5223-11e9-9cfe-e30058acf540.JPG)
![truncates](https://user-images.githubusercontent.com/22674713/55249836-64ccff00-5223-11e9-967a-c29253bde981.JPG)

Fixed #290 