### PR TITLE
First pass at allowing job submission in-place

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -113,8 +113,6 @@ class WorkflowsController < ApplicationController
   # POST /workflows/create_from_path_no_copy
   # POST /workflows/create_from_path_no_copy.json
   def create_from_path_no_copy
-    p workflow_params
-
     @workflow = Workflow.new_from_path_no_copy(workflow_params[:staging_template_dir])
     @workflow.name = workflow_params[:name] unless workflow_params[:name].blank?
     @workflow.batch_host = workflow_params[:batch_host] unless workflow_params[:batch_host].blank?

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -60,6 +60,30 @@ class Workflow < ActiveRecord::Base
     workflow
   end
 
+  # Create a new workflow from a path and attempt to load a manifest on that path. Without copying
+  #
+  # @param [String] path A path to use as a non-static template
+  # @return [Workflow] Return a new workflow based on the path
+  def self.new_from_path_no_copy(path)
+    path = Pathname.new(path).expand_path rescue Pathname.new(path)
+    workflow = Workflow.new
+    workflow.name = ''
+    workflow.batch_host = OODClusters.first.id
+    workflow.script_name = ''
+    workflow.staging_template_dir = path.to_s
+    workflow.staged_dir = path
+
+    # Attempt to load a manifest on the path, there might be one
+    manifest_path = path.join('manifest.yml')
+    if manifest_path.exist?
+      manifest = Manifest.load manifest_path
+      workflow.name = manifest.name
+      workflow.batch_host = manifest.host
+      workflow.script_name = manifest.script
+    end
+    workflow
+  end
+
   # Override of osc_machete_rails
   # places jobs into the 'projects/default' folder
   def staging_target_dir_name

--- a/app/views/workflows/_new_from_path_no_copy_form.html.erb
+++ b/app/views/workflows/_new_from_path_no_copy_form.html.erb
@@ -1,0 +1,34 @@
+<%# Uses rails_bootstrap_form gem. API at: https://github.com/bootstrap-ruby/rails-bootstrap-forms %>
+
+<%= bootstrap_form_for(workflow, url: create_from_path_no_copy_path) do |f| %>
+    <%= f.alert_message "Please fix the errors below." %>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        Path to source <strong>(Required)</strong>
+      </div>
+      <div class="panel-body">
+        <%= f.text_field :staging_template_dir, label: "Source path", required: true, help: "Enter the path to a directory on the file system. The contents of this path will be copied to a new workflow." %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        Job Attributes <strong>(Optional)</strong>
+      </div>
+      <div class="panel-body">
+        <%= f.text_field :name %>
+
+        <%= f.text_field :script_name %>
+
+        <%= f.select :batch_host, OODClusters.map { |cluster| [ "#{cluster.metadata.title}", cluster.id ] }, { label: "Cluster:", :include_blank => true }, { class: "selectpicker", id: "batch_host_select" } %>
+
+        <%= f.text_field :account, help: "Account is an optional field. If not set, the account may be auto-set by the submit filter." %>
+      </div>
+    </div>
+
+    <%= f.submit 'Save', class: 'btn btn-primary' %>
+    <%= f.button 'Reset', type: :reset, class: 'btn btn-default' %>
+
+    <%= link_to 'Back', workflows_path, class: 'btn btn-default' %>
+<% end %>

--- a/app/views/workflows/index.html.erb
+++ b/app/views/workflows/index.html.erb
@@ -20,6 +20,7 @@
               <li><a href="<%= new_workflow_path %>" data-toggle="tooltip" title="Create a new job from a template you choose">From Template</a></li>
               <% end %>
               <li><a href="<%= new_from_path_path %>">From Specified Path</a></li>
+              <li><a href="<%= new_from_path_no_copy_path %>">From Specified Path (No Copy)</a></li>
               <li role="separator" class="divider"></li>
               <li><a id="copy_button" data-toggle="tooltip" title="Copy the selected job" data-method="post" disabled>From Selected Job</a></li>
             </ul>

--- a/app/views/workflows/new_from_path_no_copy.html.erb
+++ b/app/views/workflows/new_from_path_no_copy.html.erb
@@ -1,0 +1,7 @@
+<div class="container">
+  <div class="page-header">
+    <h3>Create a new job from a path</h3>
+  </div>
+
+  <%= render 'new_from_path_no_copy_form', workflow: @workflow %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ Rails.application.routes.draw do
 
   post "create_default" => "workflows#create_default"
   get "new_from_path" => "workflows#new_from_path"
+  get "new_from_path_no_copy" => "workflows#new_from_path_no_copy"
   post "create_from_path" => "workflows#create_from_path"
+  post "create_from_path_no_copy" => "workflows#create_from_path_no_copy"
   root "workflows#index"
 
   # The priority is based upon order of creation: first created -> highest priority.


### PR DESCRIPTION
In the course of [this conversation on Discourse](https://discourse.osc.edu/t/how-do-i-change-the-default-ood-job-path-to-point-to-the-home-directory/358/3?u=rodgers.355) the question was raised: is it possible to submit a job using OnDemand's Job Composer without copying the directory? This PR implements that ability.

It may be possible/desirable to accomplish all of this from custom initializers.