### PR TITLE
Alternative no-copy workflow that does not add a new menu item

### DIFF
--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -86,14 +86,14 @@ class WorkflowsController < ApplicationController
     @workflow.script_name = workflow_params[:script_name] unless workflow_params[:script_name].blank?
     @workflow.account = workflow_params[:account] unless workflow_params[:account].blank?
 
-    if workflow_params[:should_not_copy].to_i == 1
-      # if we staged_dir is not nil, the staging_template_dir will not be copied
-      # on save in the before_create callback
-      @workflow.staged_dir = @workflow.staging_template_dir
-    else
+    if workflow_params[:copy] == 1
       # validate path we are copying from. copy_safe is a boolean, error contains the error string if false
       copy_safe, error = Filesystem.new.validate_path_is_copy_safe(@workflow.staging_template_dir.to_s)
       @workflow.errors.add(:staging_template_dir, error) unless copy_safe
+    else
+      # if we staged_dir is not nil, the staging_template_dir will not be copied
+      # on save in the before_create callback
+      @workflow.staged_dir = @workflow.staging_template_dir
     end
 
     # If the workflow passes validation but a name hasn't been assigned, set the name to the inputted path
@@ -222,6 +222,10 @@ class WorkflowsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def workflow_params
+      params.require(:copy)
+
+      params[:workflow][:copy] = params.dig(:copy, :dir).to_i
+
       params.require(:workflow).permit!
     end
 

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -86,7 +86,7 @@ class WorkflowsController < ApplicationController
     @workflow.script_name = workflow_params[:script_name] unless workflow_params[:script_name].blank?
     @workflow.account = workflow_params[:account] unless workflow_params[:account].blank?
 
-    if workflow_params[:copy] == 1
+    if copy?
       # validate path we are copying from. copy_safe is a boolean, error contains the error string if false
       copy_safe, error = Filesystem.new.validate_path_is_copy_safe(@workflow.staging_template_dir.to_s)
       @workflow.errors.add(:staging_template_dir, error) unless copy_safe
@@ -222,11 +222,11 @@ class WorkflowsController < ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def workflow_params
-      params.require(:copy)
-
-      params[:workflow][:copy] = params.dig(:copy, :dir).to_i
-
       params.require(:workflow).permit!
+    end
+
+    def copy?
+      params[:copy].to_i == 1
     end
 
     def update_jobs

--- a/app/controllers/workflows_controller.rb
+++ b/app/controllers/workflows_controller.rb
@@ -86,9 +86,15 @@ class WorkflowsController < ApplicationController
     @workflow.script_name = workflow_params[:script_name] unless workflow_params[:script_name].blank?
     @workflow.account = workflow_params[:account] unless workflow_params[:account].blank?
 
-    # validate path we are copying from. safe_path is a boolean, error contains the error string if false
-    copy_safe, error = Filesystem.new.validate_path_is_copy_safe(@workflow.staging_template_dir.to_s)
-    @workflow.errors.add(:staging_template_dir, error) unless copy_safe
+    if workflow_params[:should_not_copy].to_i == 1
+      # if we staged_dir is not nil, the staging_template_dir will not be copied
+      # on save in the before_create callback
+      @workflow.staged_dir = @workflow.staging_template_dir
+    else
+      # validate path we are copying from. copy_safe is a boolean, error contains the error string if false
+      copy_safe, error = Filesystem.new.validate_path_is_copy_safe(@workflow.staging_template_dir.to_s)
+      @workflow.errors.add(:staging_template_dir, error) unless copy_safe
+    end
 
     # If the workflow passes validation but a name hasn't been assigned, set the name to the inputted path
     if @workflow.errors.empty? && @workflow.name.blank?

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ActiveRecord::Base
   # add accessors: [ :attr1, :attr2 ] etc. when you want to add getters and
   # setters to add new attributes stored in the JSON store
   # don't remove attributes from this list going forward! only deprecate
-  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request]
+  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request, :should_not_copy]
 
   attr_accessor :staging_template_dir
 

--- a/app/models/workflow.rb
+++ b/app/models/workflow.rb
@@ -8,7 +8,7 @@ class Workflow < ActiveRecord::Base
   # add accessors: [ :attr1, :attr2 ] etc. when you want to add getters and
   # setters to add new attributes stored in the JSON store
   # don't remove attributes from this list going forward! only deprecate
-  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request, :should_not_copy]
+  store :job_attrs, coder: JSON, accessors: [:account, :job_array_request]
 
   attr_accessor :staging_template_dir
 

--- a/app/views/workflows/_new_from_path_form.html.erb
+++ b/app/views/workflows/_new_from_path_form.html.erb
@@ -10,7 +10,11 @@
       <div class="panel-body">
         <%= f.text_field :staging_template_dir, label: "Source path", required: true, help: "Enter the path to a directory on the file system." %>
 
-        <%= f.check_box :should_not_copy, label: "Do not copy this path to the workflow directory: #{workflow.staging_target_dir.to_s}" %>
+        <div class="form-group">
+          <label class="control-label" for="workflow_name">Copy directory to the workflow directory?</label>
+          <%= check_box :copy, 'dir', checked_value: 1, unchecked_value: 0, checked: true %>
+          <span class="help-block">Unchecking will run this job in-place which is ideal when the directory contains multi-gigabyte files or 1ks of files.</span>
+        </div>
       </div>
     </div>
 

--- a/app/views/workflows/_new_from_path_form.html.erb
+++ b/app/views/workflows/_new_from_path_form.html.erb
@@ -12,7 +12,7 @@
 
         <div class="form-group">
           <label class="control-label" for="workflow_name">Copy directory to the workflow directory?</label>
-          <%= check_box :copy, 'dir', checked_value: 1, unchecked_value: 0, checked: true %>
+          <%= check_box_tag :copy, 1, options: {:checked => true} %>
           <span class="help-block">Unchecking will run this job in-place which is ideal when the directory is multiple gigabytes or contains 1ks of files.</span>
         </div>
       </div>

--- a/app/views/workflows/_new_from_path_form.html.erb
+++ b/app/views/workflows/_new_from_path_form.html.erb
@@ -13,7 +13,7 @@
         <div class="form-group">
           <label class="control-label" for="workflow_name">Copy directory to the workflow directory?</label>
           <%= check_box :copy, 'dir', checked_value: 1, unchecked_value: 0, checked: true %>
-          <span class="help-block">Unchecking will run this job in-place which is ideal when the directory contains multi-gigabyte files or 1ks of files.</span>
+          <span class="help-block">Unchecking will run this job in-place which is ideal when the directory is multiple gigabytes or contains 1ks of files.</span>
         </div>
       </div>
     </div>

--- a/app/views/workflows/_new_from_path_form.html.erb
+++ b/app/views/workflows/_new_from_path_form.html.erb
@@ -8,7 +8,9 @@
         Path to source <strong>(Required)</strong>
       </div>
       <div class="panel-body">
-        <%= f.text_field :staging_template_dir, label: "Source path", required: true, help: "Enter the path to a directory on the file system. The contents of this path will be copied to a new workflow." %>
+        <%= f.text_field :staging_template_dir, label: "Source path", required: true, help: "Enter the path to a directory on the file system." %>
+
+        <%= f.check_box :should_not_copy, label: "Do not copy this path to the workflow directory: #{workflow.staging_target_dir.to_s}" %>
       </div>
     </div>
 


### PR DESCRIPTION
Alternative to #301.

- Ask if the workflow dir should not be copied, avoids needing to have a default checked checkbox which bootstrap_form_for does not support
- Add `Workflow#should_not_copy` member so that bootstrap_form_for doesn't complain
- Add flow control to skip copy safe check if we are not copying