### PR TITLE
Fix issue where missing database prevents app launch

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../boot', __FILE__)
-
 require 'rails/all'
+require 'fileutils'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -23,6 +23,18 @@ module JobConstructor
     if ::Configuration.load_external_config?
       config.paths["config/initializers"] << ::Configuration.custom_initializers_root.to_s
       config.paths["app/views"].unshift ::Configuration.custom_views_root.to_s
+    end
+
+    # Handle case where app database file is missing and user does not use the Dashboard to launch app
+    if (! ::Configuration.database_path.file?) || ::Configuration.database_path.empty?
+      p 'Building the database'
+      require 'rake'
+      FileUtils.chdir ::Configuration.dataroot.parent do
+        # Rake::Task.clear
+        load_tasks
+        ::Configuration.production_database_path.parent.mkpath
+        Rake::Task['db:setup'].invoke
+      end
     end
 
     # Do not swallow errors in after_commit/after_rollback callbacks.

--- a/config/configuration_singleton.rb
+++ b/config/configuration_singleton.rb
@@ -96,6 +96,16 @@ class ConfigurationSingleton
     # FIXME: add support/handling for DATABASE_URL
     Pathname.new(ENV["DATABASE_PATH"] || dataroot.join('production.sqlite3')).expand_path
   end
+
+  def database_path
+    {
+      'test' => Pathname.new('db/test.sqlite3'),
+      'development' => Pathname.new('db/development.sqlite3')
+    }.fetch(
+      rails_env,
+      production_database_path
+    )
+  end
   
   def whitelist_paths
     ENV['WHITELIST_PATH'].to_s.strip.split(":")

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,14 +11,14 @@ default: &default
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: <%= Configuration.database_path.to_s %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: <%= Configuration.database_path.to_s %>
 
 production:
   <<: *default


### PR DESCRIPTION
On app start up checks to see if the application file exists and is not empty; if it is either the app runs the Rake `db:setup` task.

Fixes #306.